### PR TITLE
Fix for filtering on loot tables defined in non-ascending order

### DIFF
--- a/AtlasLoot/Core/Filter.lua
+++ b/AtlasLoot/Core/Filter.lua
@@ -111,7 +111,7 @@ function AtlasLoot_HideNoUsableItems()
 	local pFrame = AtlasLootItemsFrame.refreshOri[4] 	
 	local tablebase = AtlasLoot_Data[dataID]
 	if not tablebase or dataID == "WishList" or dataID == "SearchResult" or dataSource == "AtlasLootCrafting" then return end
-	table.sort(tablebase, function(a, b) return a[1] < b[1]	end) -- Re-sort the loot table since it's assumed that the items were defined in slot order
+	table.sort(tablebase, function(a, b) return a[1] < b[1]	end) -- Sort the loot table to ensure ascending slot order
 	local itemCount = 0
 	local countAll = 1
 	local count = 0

--- a/AtlasLoot/Core/Filter.lua
+++ b/AtlasLoot/Core/Filter.lua
@@ -111,6 +111,7 @@ function AtlasLoot_HideNoUsableItems()
 	local pFrame = AtlasLootItemsFrame.refreshOri[4] 	
 	local tablebase = AtlasLoot_Data[dataID]
 	if not tablebase or dataID == "WishList" or dataID == "SearchResult" or dataSource == "AtlasLootCrafting" then return end
+	table.sort(tablebase, function(a, b) return a[1] < b[1]	end) -- Re-sort the loot table since it's assumed that the items were defined in slot order
 	local itemCount = 0
 	local countAll = 1
 	local count = 0


### PR DESCRIPTION
The filtering logic assumes that loot table definitions are created in ascending order based on slot. This is so that when one slot gets filtered out it can push the slots below it up. This isn't always the case though, as some loot tables are defined out of order so that definitions are simpler to read for things like item sets. 

This can be fixed by sorting the loot table by page slots before filtering it.

Here's an example using the 'Weapon Sets' page, which you can reach by selecting Sets/Collections -> Misc Dungeon Sets -> Spider's Kiss or Dal'Rend's Arms
<details>
<summary>Unfiltered:</summary>
<img width="693" height="692" alt="image" src="https://github.com/user-attachments/assets/6af33f39-a20c-4251-b9ed-3ab00111ab66" />
</details>

<details>
<summary>Filtered Before:</summary>
<img width="685" height="685" alt="image" src="https://github.com/user-attachments/assets/68712571-d183-47d7-929e-36def1d763d6" />
</details>

<details>
<summary>Filtered After:</summary>
<img width="694" height="690" alt="image" src="https://github.com/user-attachments/assets/7e81ab0e-cfa6-4b24-9e51-f8e80d02b1c2" />
</details>