### PR TITLE
Valor's Expedition referencing wrong stringtable

### DIFF
--- a/AtlasLoot/TableRegister/loottables.en.lua
+++ b/AtlasLoot/TableRegister/loottables.en.lua
@@ -566,8 +566,8 @@ end
   -- Sepulcher
 	AtlasLoot_TableNames["Sepulcher"] = { BabbleEpoch["Sepulcher"], "AtlasLootOriginalWoW" };
   -- Valors Expedition
-	AtlasLoot_TableNames["Valorsexp"] = { BabbleFaction["Valor´s Expedition"], "AtlasLootOriginalWoW" };
-	AtlasLoot_TableNames["Valorsexp2"] = { BabbleFaction["Valor´s Expedition"], "AtlasLootOriginalWoW" };
+	AtlasLoot_TableNames["Valorsexp"] = { BabbleEpoch["Valor´s Expedition"], "AtlasLootOriginalWoW" };
+	AtlasLoot_TableNames["Valorsexp2"] = { BabbleEpoch["Valor´s Expedition"], "AtlasLootOriginalWoW" };
 
 --------------
 --- Trades ---


### PR DESCRIPTION
Now correctly pulls from BabbleEpoch instead of BabbleFaction.

Fixes the Valor's Expedition page not having a title, and showing up as 'Unknown' on search results and wishlists.

<img width="496" height="364" alt="image" src="https://github.com/user-attachments/assets/8132c447-e177-4d18-954c-6c4e36920701" />
